### PR TITLE
feat: allow implicit usings

### DIFF
--- a/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
+++ b/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
@@ -8,6 +8,6 @@
     <Description>Allegro Dotnet SDK</Description>
     <PackageTags>MSBuild MSBuildSdk</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.2.0</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Allegro.DotnetSdk/Sdk/Sdk.props
+++ b/src/Allegro.DotnetSdk/Sdk/Sdk.props
@@ -13,10 +13,14 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <Nullable>enable</Nullable>
-        <ImplicitUsings>disable</ImplicitUsings>
+        <ImplicitUsings>enable</ImplicitUsings>
         <!-- Documentation can be enforced per-project -->
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
+
+    <ItemGroup Label="ImplicitUsings additional includes">
+        <Using Include="System.Collections.Immutable" />
+    </ItemGroup>
 
     <PropertyGroup Label="Build Output">
         <RepoRoot Condition="'$(RepoRoot)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', 'global.json'))</RepoRoot>

--- a/src/Allegro.DotnetSdk/Sdk/Sdk.targets
+++ b/src/Allegro.DotnetSdk/Sdk/Sdk.targets
@@ -1,2 +1,16 @@
 <Project>
+    <!-- Empty file prevents accidental inclusion of files from directories above -->
+
+    <!-- 
+    According to https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2022#import-order,
+    Directory.Build.props is imported very early. If the global using System.Net.Http
+    is added by some file that is imported later, then the Remove in Directory.Build.props
+    cannot affect the item that does not exist yet. It'd work better
+    in Directory.Build.targets.
+    
+    More: https://stackoverflow.com/questions/52866794/why-doesnt-directory-build-props-work-when-building-a-solution-using-visual-stu
+    -->
+    <ItemGroup Label="ImplicitUsings additional removes">
+        <Using Remove="Microsoft.Extensions.Logging" />
+    </ItemGroup>
 </Project>

--- a/src/Allegro.DotnetSdk/Sdk/Sdk.targets
+++ b/src/Allegro.DotnetSdk/Sdk/Sdk.targets
@@ -12,5 +12,6 @@
     -->
     <ItemGroup Label="ImplicitUsings additional removes">
         <Using Remove="Microsoft.Extensions.Logging" />
+        <Using Remove="System.Net.Http" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Enable implicit using with additional removes specific to Allegro:
- we use `Serilog` instead of `Microsoft.Extensions.Logging` (so that we override in `Sdk.targets`)
- we want to explicitly enforce devs to add `System.Net.Http` (so that we override in `Sdk.targets`) so that they think twice
- as `ImplicitUsings` adds `System.Collections.Generic` we want to additionally include `System.Collections.Immutable`