### PR TITLE
feat: allow to disable treating warnings as errors for local development

### DIFF
--- a/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
+++ b/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
@@ -8,6 +8,6 @@
     <Description>Allegro Dotnet SDK</Description>
     <PackageTags>MSBuild MSBuildSdk</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.2.1</PackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Allegro.DotnetSdk/Sdk/Sdk.props
+++ b/src/Allegro.DotnetSdk/Sdk/Sdk.props
@@ -10,13 +10,17 @@
         <LangVersion>latest</LangVersion>
         <AnalysisMode>Recommended</AnalysisMode>
         <AnalysisLevel>latest</AnalysisLevel>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <!-- Documentation can be enforced per-project -->
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
     </PropertyGroup>
+
+    <!-- Some devs might want to turn off errors for warning for local development -->
+    <PropertyGroup Label="Project Settings" Condition=" '$(TreatWarningsAsErrors)' != 'false' ">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup> 
 
     <ItemGroup Label="ImplicitUsings additional includes">
         <Using Include="System.Collections.Immutable" />

--- a/src/Allegro.DotnetSdk/Sdk/Sdk.props
+++ b/src/Allegro.DotnetSdk/Sdk/Sdk.props
@@ -15,12 +15,9 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <!-- Documentation can be enforced per-project -->
         <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <!-- Some devs might want to turn off errors for warning for local development -->
+        <TreatWarningsAsErrors Condition=" '$(TreatWarningsAsErrors)' != 'false' ">true</TreatWarningsAsErrors>
     </PropertyGroup>
-
-    <!-- Some devs might want to turn off errors for warning for local development -->
-    <PropertyGroup Label="Project Settings" Condition=" '$(TreatWarningsAsErrors)' != 'false' ">
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    </PropertyGroup> 
 
     <ItemGroup Label="ImplicitUsings additional includes">
         <Using Include="System.Collections.Immutable" />


### PR DESCRIPTION
For those who want to disable errors for warnings for local development, create env variable:

```bash
export TreatWarningsAsErrors='false'                                                                                     
```

This should simplify local development, as temporary code will compile.