### PR TITLE
Use supported GitHub Actions

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -27,9 +27,9 @@ jobs:
     outputs:
       nupkgFilename: ${{ steps.nupkg.outputs.filename }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
           6.0.x


### PR DESCRIPTION
Update to v3 actions as older ones are no longer supported.