### PR TITLE
fix: correct Condition for stylecop.json inclusion

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: src/${{ inputs.projectName }}
+        working-directory: ./
     outputs:
       nupkgFilename: ${{ steps.nupkg.outputs.filename }}
     steps:
@@ -64,7 +64,7 @@ jobs:
         if: inputs.publish
         with:
           name: package
-          path: src/${{ inputs.projectName }}/package
+          path: package
   publish:
     runs-on: windows-latest
     if: inputs.publish

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It's necessary to include `Allegro.DotnetSdk` with the desired version in `globa
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Allegro.DotnetSdk": "2.1.0"
+    "Allegro.DotnetSdk": "2.2.2"
   }
 }
 
@@ -97,7 +97,7 @@ Configure in `*.csproj` - project settings:
 This SDK provides some default configuration (rules severity) for selected analyzers: StyleCop, Meziantou and AsyncFixer. It doesn't actually reference them. Avoiding direct references ensures that developers can seamlessly apply and update analyzers without being tied to specific versions.
 
 To add analyzers, include the following in your `Directory.Build.props` or `Directory.Packages.props` file:
-	
+
 ```xml
 <Project>
     <!-- ... -->

--- a/src/Allegro.DotnetSdk.Tests/projects/Net8SdkValid/global.json
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net8SdkValid/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100"
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
+++ b/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PackageVersion>2.2.1</PackageVersion>
+    <PackageVersion>2.2.2</PackageVersion>
     <IsPackable>true</IsPackable>
     <DevelopmentDependency>true</DevelopmentDependency>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Allegro.DotnetSdk/Sdk/Allegro.NET.Sdk.CSharp.targets
+++ b/src/Allegro.DotnetSdk/Sdk/Allegro.NET.Sdk.CSharp.targets
@@ -7,10 +7,9 @@
   </PropertyGroup>
 
   <!-- 
-    Include stylecop configuration if we include StyleCop analyzer within this Sdk,
-    or if it was included externally as GlobalPackageReference when CPM is enabled.
+    Include stylecop configuration if StyleCop was included externally as GlobalPackageReference when CPM is enabled.
   -->
-  <ItemGroup Condition="'$(AllegroDotnetSdkEnableStyleCopConfig)' == 'true' Or @(GlobalPackageReference->WithMetadataValue('Identity','StyleCop.Analyzers')->Count()) > 0)">
+  <ItemGroup Condition="'$(AllegroDotnetSdkEnableStyleCopConfig)' == 'true' And @(GlobalPackageReference->WithMetadataValue('Identity','StyleCop.Analyzers')->Count()) > 0">
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 


### PR DESCRIPTION
Condition for `stylecop.json` inclusion in `Allegro.NET.Sdk.CSharp.targets` had an extra `)` at the end after previous PR removed part of condition, which resulted in MSBuild parsing errors.