### PR TITLE
Upgrade all GitHub Actions to latest versions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -33,9 +33,9 @@ jobs:
     outputs:
       nupkgFilename: ${{ steps.nupkg.outputs.filename }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             6.0.x
@@ -60,7 +60,7 @@ jobs:
             echo "File '$NUPKG' does not exist";
             exit 1;
           fi
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v7
         if: inputs.publish
         with:
           name: package
@@ -70,12 +70,12 @@ jobs:
     if: inputs.publish
     needs: [build]
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v8
         with:
           name: package
           path: unsigned
       - name: NuGet Install
-        uses: NuGet/setup-nuget@v1.0.5
+        uses: NuGet/setup-nuget@v2
         with:
           nuget-version: latest
       - name: Setup Certificate
@@ -92,7 +92,7 @@ jobs:
           echo "SM_CLIENT_CERT_FILE=D:\\cognite_code_signing_github_actions.p12" >> "$GITHUB_ENV"
         shell: bash
       - name: Configure Digicert Secure Software Manager
-        uses: digicert/ssm-code-signing@v0.0.2
+        uses: digicert/ssm-code-signing@v1
         env:
           SM_API_KEY: ${{ env.SM_API_KEY }}
           SM_CLIENT_CERT_PASSWORD: ${{ env.SM_CLIENT_CERT_PASSWORD }}
@@ -113,7 +113,7 @@ jobs:
           nuget verify -All "%cd%\signed\*.nupkg"
         shell: cmd
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             6.0.x


### PR DESCRIPTION
## Summary

- Upgrades all GitHub Actions in the CI/publish workflow to their latest major versions
- Adds Dependabot configuration for automated weekly GitHub Actions updates

## Changes

### Action upgrades in `.github/workflows/template.yml`

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v3 | **v6** |
| `actions/setup-dotnet` | v3 | **v5** |
| `actions/upload-artifact` | v3 | **v7** |
| `actions/download-artifact` | v3 | **v8** |
| `NuGet/setup-nuget` | v1.0.5 | **v2** |
| `digicert/ssm-code-signing` | v0.0.2 | **v1** |

### New file: `.github/dependabot.yml`

Configures Dependabot to automatically open PRs for GitHub Actions version updates on a weekly schedule.

## Why

GitHub has deprecated v3 of the artifact actions, causing workflows to automatically fail with:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

All other actions were also outdated by multiple major versions. Adding Dependabot ensures this won't happen again.