### PR TITLE
Drop .NET 6 support, add .NET 10, bump to v2.3.0

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -38,8 +38,8 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
+            10.0.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -116,7 +116,7 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
+            10.0.x
       - name: Push package
         run: dotnet nuget push signed/${{needs.build.outputs.nupkgFilename}} --api-key ${{ secrets.nugetApiKey }} --source https://api.nuget.org/v3/index.json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,14 +6,14 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.0">
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="xunit" Version="2.6.5" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageVersion Include="FluentAssertions" Version="7.2.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The SDK is versioned and published on nuget. It can be imported into dotnet proj
 
 ## Using the SDK
 
-The SDK is meant to be easily importable - only a few initial config lines are required to bring its benefits. The SDK also makes it possible to override any of its default settings. Version 2+ will work only with .NET SDK v8+.
+The SDK is meant to be easily importable - only a few initial config lines are required to bring its benefits. The SDK also makes it possible to override any of its default settings. Version 2+ will work only with .NET SDK v8+. Supported target frameworks: net8.0 and net10.0.
 
 ## Importing
 
@@ -27,7 +27,7 @@ It's necessary to include `Allegro.DotnetSdk` with the desired version in `globa
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Allegro.DotnetSdk": "2.2.2"
+    "Allegro.DotnetSdk": "2.3.0"
   }
 }
 

--- a/src/Allegro.DotnetSdk.Tests/projects/Net10LibValid/Class1.cs
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net10LibValid/Class1.cs
@@ -1,0 +1,12 @@
+namespace Net10LibValid;
+
+/// <summary>
+/// Docs
+/// </summary>
+public class Class1
+{
+    /// <summary>
+    /// Docs
+    /// </summary>
+    public static int Number { get; set; }
+}

--- a/src/Allegro.DotnetSdk.Tests/projects/Net10LibValid/Net10LibValid.csproj
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net10LibValid/Net10LibValid.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Allegro.DotnetSdk.Tests/projects/Net10LibValid/global.json
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net10LibValid/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/Program.cs
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/Program.cs
@@ -1,2 +1,0 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");

--- a/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/README.md
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/README.md
@@ -1,3 +1,0 @@
-This project should fail with an error message:
-
-> error : Allegro.DotnetSdk requires .NET SDK v8.0.100+ to be used, but 6.0.x was found.

--- a/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/global.json
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestFeature"
-  }
-}

--- a/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/message.txt
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net6SdkError/message.txt
@@ -1,1 +1,0 @@
-Allegro.DotnetSdk requires .NET SDK v8.0.100+ to be used

--- a/src/Allegro.DotnetSdk.Tests/projects/Net8SdkValid/Net8SdkValid.csproj
+++ b/src/Allegro.DotnetSdk.Tests/projects/Net8SdkValid/Net8SdkValid.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
+++ b/src/Allegro.DotnetSdk/Allegro.DotnetSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <PackageVersion>2.2.2</PackageVersion>
+    <PackageVersion>2.3.0</PackageVersion>
     <IsPackable>true</IsPackable>
     <DevelopmentDependency>true</DevelopmentDependency>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -10,7 +10,6 @@
     <PackageDescription>Allegro Dotnet SDK</PackageDescription>
     <PackageTags>$(Tags) MSBuild MSBuildSdk</PackageTags>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-    <!-- NU5128: Add lib or ref assemblies for the net6.0 target framework -->
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
   


### PR DESCRIPTION
## Summary

- **Version bump**: `2.2.2` → `2.3.0`
- **Drop .NET 6**: Remove `6.0.x` SDK from CI, remove `Net6SdkError` test fixture
- **Add .NET 10**: Install `10.0.x` SDK in CI, add `Net10LibValid` test fixture targeting `net10.0`
- **Fix test fixture**: `Net8SdkValid` was targeting `net6.0` — corrected to `net8.0`
- **Bump test dependencies**:
  - `coverlet.collector` 6.0.0 → 6.0.4
  - `FluentAssertions` 6.12.0 → 7.2.2 (latest below v8 license change)
  - `Microsoft.NET.Test.Sdk` 17.8.0 → 17.14.1
  - `xunit` 2.6.5 → 2.9.3
  - `xunit.runner.visualstudio` 2.5.6 → 2.8.2
- **README**: Updated version reference and documented supported TFMs (net8.0, net10.0)

## Notes

- Minimum .NET SDK requirement stays at **8.0** (no change to `Sdk.props` validation)
- The `Net6SdkError` test was removed because without .NET 6 SDK installed in CI, the test would fail for the wrong reason (SDK not found vs. validation error)
- The `Net10LibValid` test requires .NET 10 SDK to pass — this will work in CI where `10.0.x` is installed